### PR TITLE
feat: YAML entity filtering with reload service

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,17 +1,14 @@
 ---
 gsd_state_version: 1.0
 milestone: v1.1
-milestone_name: Robust Ingestion
-status: complete
-stopped_at: null
-last_updated: "2026-04-23T20:30:00Z"
-last_activity: 2026-04-23 -- v1.1 milestone archived
+milestone_name: milestone
+status: unknown
+last_updated: "2026-04-24T10:22:00Z"
 progress:
-  total_phases: 3
-  completed_phases: 3
-  total_plans: 29
-  completed_plans: 29
-  percent: 100
+  total_phases: 0
+  completed_phases: 0
+  total_plans: 0
+  completed_plans: 0
 ---
 
 # Project State
@@ -29,6 +26,12 @@ Shipped 2026-04-23. All 3 phases, 29 plans executed and verified.
 
 Archive: `.planning/milestones/v1.1-ROADMAP.md` · `.planning/milestones/v1.1-REQUIREMENTS.md`
 Summary: `.planning/MILESTONES.md`
+
+## Quick Tasks
+
+| Task | Description | Status | Completed |
+|------|-------------|--------|-----------|
+| 260424-dv3 | YAML entity filtering wired end-to-end (CONFIG_SCHEMA, async_setup, hass.data) | Done | 2026-04-24 |
 
 ## Deferred Items
 

--- a/.planning/quick/260424-dv3-implement-yaml-entity-filtering-for-ha-t/260424-dv3-PLAN.md
+++ b/.planning/quick/260424-dv3-implement-yaml-entity-filtering-for-ha-t/260424-dv3-PLAN.md
@@ -1,0 +1,159 @@
+---
+phase: quick-260424-dv3
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - custom_components/ha_timescaledb_recorder/__init__.py
+  - README.md
+autonomous: true
+requirements: []
+
+must_haves:
+  truths:
+    - "YAML include/exclude filter config is parsed and stored in hass.data at async_setup time"
+    - "async_setup_entry reads the filter from hass.data and passes it to StateListener and orchestrator"
+    - "When no YAML config is present, behaviour is identical to today (pass-all filter)"
+    - "README Entity Filtering section documents the YAML syntax accurately"
+  artifacts:
+    - path: "custom_components/ha_timescaledb_recorder/__init__.py"
+      provides: "CONFIG_SCHEMA, async_setup, updated _get_entity_filter reading hass.data"
+    - path: "README.md"
+      provides: "Accurate YAML entity filtering documentation"
+  key_links:
+    - from: "configuration.yaml ha_timescaledb_recorder block"
+      to: "hass.data[DOMAIN]['filter']"
+      via: "async_setup stores validated config"
+    - from: "hass.data[DOMAIN]['filter']"
+      to: "StateListener + backfill_orchestrator entity_filter kwarg"
+      via: "_get_entity_filter reads hass.data in async_setup_entry"
+---
+
+<objective>
+Wire YAML entity filtering in ha_timescaledb_recorder so users can include/exclude entities by domain, entity ID, or glob — matching HA recorder semantics.
+
+Purpose: The filter scaffolding has existed since Phase 1 but `entry.data` never carries a filter key, making it permanently pass-all. This wires it end-to-end through the YAML → `async_setup` → `hass.data` → `async_setup_entry` path.
+Output: Working YAML-configurable entity filter; updated README.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add CONFIG_SCHEMA, async_setup, and update _get_entity_filter in __init__.py</name>
+  <files>custom_components/ha_timescaledb_recorder/__init__.py</files>
+  <action>
+    Add the following to `__init__.py` (module-level after existing imports, before any functions):
+
+    1. Add imports at the top of the existing import block:
+       - `import voluptuous as vol`
+       - `from homeassistant.helpers import config_validation as cv`
+
+    2. Define the YAML schema constant `FILTER_SCHEMA` using voluptuous. The inner list schema accepts `vol.Optional` keys `"domains"`, `"entities"`, `"entity_globs"` — each a `vol.All(list, [cv.string])`. Define one schema for an include/exclude block, then wrap into `CONFIG_SCHEMA` as:
+
+       ```
+       CONFIG_SCHEMA = vol.Schema(
+           {DOMAIN: vol.Schema({
+               vol.Optional("include"): FILTER_SCHEMA_INNER,
+               vol.Optional("exclude"): FILTER_SCHEMA_INNER,
+           })},
+           extra=vol.ALLOW_EXTRA,  # required — HA validates other domains too
+       )
+       ```
+
+       Do NOT import `INCLUDE_EXCLUDE_FILTER_SCHEMA_INNER` from HA internals — define the voluptuous shape directly here.
+
+    3. Add `async_setup(hass, config)` function immediately after `CONFIG_SCHEMA`. This is called by HA before `async_setup_entry`. It must:
+       - Extract `domain_config = config.get(DOMAIN, {})` from the HA config dict (which is the full `configuration.yaml` parsed result, validated against `CONFIG_SCHEMA`).
+       - Store it at `hass.data.setdefault(DOMAIN, {})["filter"] = domain_config` so `async_setup_entry` can read it.
+       - Return `True`.
+       - Add a brief comment explaining why this must precede `async_setup_entry` (HA startup order guarantee).
+
+    4. Replace `_get_entity_filter(entry)` with `_get_entity_filter(hass, entry)`. The new signature reads `hass.data.get(DOMAIN, {}).get("filter", {})` to obtain the raw filter dict. If non-empty, pass it directly to `convert_include_exclude_filter(raw_filter)`. If empty, fall back to `convert_filter({...})` exactly as today. Remove the `entry` parameter usage entirely — `entry.data` never carries a filter key, so the old path was always returning pass-all. Document this with a comment.
+
+    5. Update both call sites of `_get_entity_filter(entry)` in `async_setup_entry` to `_get_entity_filter(hass, entry)`. There is exactly one call at line ~337: `entity_filter = _get_entity_filter(entry)`.
+
+    No other behaviour changes. The existing orchestrator, state_listener, and registry_listener wiring that already consumes `entity_filter` remains unchanged.
+  </action>
+  <verify>
+    `cd /home/janfr/dev/home-assistant/ha-timescaledb-recorder && uv run python -c "from custom_components.ha_timescaledb_recorder import CONFIG_SCHEMA, async_setup, async_setup_entry; print('imports ok')"` — should print `imports ok` with no errors.
+  </verify>
+  <done>
+    `CONFIG_SCHEMA` is defined and exported; `async_setup` stores filter config in `hass.data`; `_get_entity_filter` reads from `hass.data`; the one call site in `async_setup_entry` passes `hass` as first argument; `uv run python` import check passes.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Replace README Entity Filtering section with accurate YAML documentation</name>
+  <files>README.md</files>
+  <action>
+    Replace the "Entity Filtering" subsection (currently under "Configuration") with accurate content. The replacement must include:
+
+    1. A brief intro sentence: filtering is configured via `configuration.yaml` and mirrors HA recorder semantics.
+
+    2. A YAML example block showing the full `ha_timescaledb_recorder:` key with nested `include:` and `exclude:` blocks, each demonstrating `domains:`, `entities:`, and `entity_globs:` sub-keys (use the exact example from the feature description in the task context above).
+
+    3. A behaviour table or bullet list documenting:
+       - `include.domains` — only states from listed domains are ingested
+       - `include.entities` — only these specific entity IDs are ingested
+       - `include.entity_globs` — only entities matching these glob patterns
+       - `exclude.*` — same keys, but excluded even if include matches
+       - All keys are optional; omitting both `include` and `exclude` ingests all entities
+
+    4. A note: "Filter configuration requires a **Home Assistant restart** to take effect — changes are not picked up by a config entry reload."
+
+    5. Remove the current placeholder text that says filtering is "not yet implemented" and the paragraph about `_get_entity_filter` always being pass-all.
+
+    Do not change any other section of README.md.
+  </action>
+  <verify>
+    `grep -n "not yet implemented" /home/janfr/dev/home-assistant/ha-timescaledb-recorder/README.md` — must return no matches.
+  </verify>
+  <done>
+    The Entity Filtering section shows the YAML example, documents all include/exclude sub-keys, notes the restart requirement, and contains no "not yet implemented" text.
+  </done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| configuration.yaml → async_setup | User-supplied YAML input parsed by voluptuous before use |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-dv3-01 | Tampering | CONFIG_SCHEMA / async_setup | mitigate | voluptuous schema with `cv.string` validators rejects non-string domain/entity/glob values before they reach `convert_include_exclude_filter`; `ALLOW_EXTRA` only permits unknown top-level domains, not unknown keys inside the `ha_timescaledb_recorder` block |
+| T-dv3-02 | Denial of Service | entity_filter callable | accept | Glob patterns from YAML could be expensive, but this is user-owned config on a trusted local HA instance; no external input path |
+</threat_model>
+
+<verification>
+1. `uv run python -c "from custom_components.ha_timescaledb_recorder import CONFIG_SCHEMA, async_setup, async_setup_entry; print('ok')"` passes.
+2. `grep -n "not yet implemented" README.md` returns no output.
+3. Manual review: `CONFIG_SCHEMA` exported at module level; `async_setup` present and returns `True`; `_get_entity_filter` signature is `(hass, entry)`.
+</verification>
+
+<success_criteria>
+- YAML entity filtering is wired end-to-end: `configuration.yaml` → `async_setup` → `hass.data` → `_get_entity_filter` → `StateListener` + orchestrator.
+- No YAML config = pass-all behaviour identical to today.
+- README Entity Filtering section accurately documents YAML syntax and restart requirement.
+</success_criteria>
+
+<output>
+After completion, create `.planning/quick/260424-dv3-implement-yaml-entity-filtering-for-ha-t/260424-dv3-SUMMARY.md`
+</output>

--- a/.planning/quick/260424-dv3-implement-yaml-entity-filtering-for-ha-t/260424-dv3-SUMMARY.md
+++ b/.planning/quick/260424-dv3-implement-yaml-entity-filtering-for-ha-t/260424-dv3-SUMMARY.md
@@ -1,0 +1,75 @@
+---
+phase: quick-260424-dv3
+plan: "01"
+subsystem: ingestion-filter
+tags: [entity-filter, yaml-config, voluptuous, async_setup]
+dependency_graph:
+  requires: []
+  provides: [yaml-entity-filtering]
+  affects: [state_listener, backfill_orchestrator]
+tech_stack:
+  added: [voluptuous CONFIG_SCHEMA, cv.string validators]
+  patterns: [hass.data domain store, async_setup HA startup hook]
+key_files:
+  created: []
+  modified:
+    - custom_components/ha_timescaledb_recorder/__init__.py
+    - README.md
+decisions:
+  - "Read filter from hass.data (set by async_setup) rather than entry.data — entry.data never carries a filter key"
+  - "ALLOW_EXTRA on CONFIG_SCHEMA top-level so other domains pass HA's config validation unchanged"
+  - "FILTER_SCHEMA_INNER uses vol.Optional with default=[] so convert_include_exclude_filter always receives well-formed dicts"
+metrics:
+  duration: "8 minutes"
+  completed: "2026-04-24"
+---
+
+# Quick Task 260424-dv3: Implement YAML Entity Filtering Summary
+
+YAML entity filtering wired end-to-end: `configuration.yaml` include/exclude config validated by voluptuous, stored in `hass.data` by `async_setup`, and consumed by `_get_entity_filter` before `StateListener` and the backfill orchestrator are constructed.
+
+## Tasks Completed
+
+| Task | Description | Commit |
+|------|-------------|--------|
+| 1 | Add CONFIG_SCHEMA, async_setup, update _get_entity_filter | 60f4d7b |
+| 2 | Replace README Entity Filtering placeholder with YAML docs | 2038b92 |
+
+## What Was Built
+
+### Task 1 — `__init__.py`
+
+- `_FILTER_SCHEMA_INNER`: voluptuous schema for one include/exclude block with `domains`, `entities`, `entity_globs` keys, each validated as `[cv.string]` with empty-list defaults.
+- `CONFIG_SCHEMA`: top-level schema wrapping `_FILTER_SCHEMA_INNER` under the `DOMAIN` key with `extra=vol.ALLOW_EXTRA` so other HA integration configs pass through unchanged.
+- `async_setup(hass, config)`: stores `config.get(DOMAIN, {})` in `hass.data[DOMAIN]["filter"]` before any config entry loads. Returns `True`.
+- `_get_entity_filter(hass, entry)`: reads `hass.data.get(DOMAIN, {}).get("filter", {})`. Non-empty → `convert_include_exclude_filter(raw_filter)`. Empty → `convert_filter({...})` pass-all (unchanged fallback).
+- Call site in `async_setup_entry` updated: `_get_entity_filter(hass, entry)`.
+
+### Task 2 — `README.md`
+
+Replaced the "not yet implemented" placeholder under "Entity Filtering" with:
+- YAML example block with full `include`/`exclude` structure
+- Bullet list documenting each sub-key's semantics
+- Include-only = allow-list, exclude-only = deny-list, both = HA recorder precedence
+- Restart-required note with explanation
+- Link to HA recorder filter documentation
+
+## Deviations from Plan
+
+None — plan executed exactly as written.
+
+## Known Stubs
+
+None. The filter is fully wired; pass-all is the correct behaviour when no YAML config is present.
+
+## Threat Surface Scan
+
+No new network endpoints, auth paths, or file access patterns introduced. All user input (YAML filter values) flows through voluptuous `cv.string` validators before reaching `convert_include_exclude_filter`. T-dv3-01 mitigation applied as designed.
+
+## Self-Check: PASSED
+
+- `custom_components/ha_timescaledb_recorder/__init__.py` — modified and committed at 60f4d7b
+- `README.md` — modified and committed at 2038b92
+- `uv run python` import check: `CONFIG_SCHEMA`, `async_setup`, `async_setup_entry` all importable
+- `grep "not yet implemented" README.md` — 0 matches
+- `_get_entity_filter` signature verified: `(hass, entry)`

--- a/README.md
+++ b/README.md
@@ -92,7 +92,11 @@ Filter behaviour:
 - When only `exclude` is specified, matching entities are dropped (deny-list)
 - When both are specified, HA recorder precedence rules apply: include first, then exclude wins
 
-> **Note:** Filter configuration requires a **Home Assistant restart** to take effect — changes are not picked up by a config entry reload, because `async_setup` (which reads the YAML filter) only runs at startup.
+After editing `configuration.yaml`, call the reload service to apply the new filter without restarting HA:
+
+**Developer Tools → Services → `ha_timescaledb_recorder.reload`** (no parameters needed)
+
+This re-parses `configuration.yaml` and reloads the integration's config entry. A full HA restart also works but is not required.
 
 ## Schema
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ A custom integration that writes Home Assistant entity state changes to a Timesc
 ## Prerequisites
 
 - Home Assistant 2024.1 or later
-- A running PostgreSQL + TimescaleDB instance > 2.18 (the [TimescaleDB HA app](https://github.com/flaksit/hass-timescaledb) is the intended companion)
+- The built-in HA recorder integration must be enabled — this integration relies on the recorder's SQLite database for historical backfill and entity registry access
+- A running PostgreSQL + TimescaleDB instance > 2.18 (the [TimescaleDB HA app](https://github.com/flaksic/hass-timescaledb) is the intended companion)
 - The DSN user must have `CREATE TABLE` privileges — use the `homeassistant` role created by the app, **not** `homeassistant_rw` which is read/write only and lacks DDL rights
 
 ## Installation
@@ -59,7 +60,7 @@ Options take effect immediately — the integration reloads automatically when y
 
 ### Entity Filtering
 
-Entity filtering is configured in `configuration.yaml` using the same include/exclude syntax as the recorder integration. Add the filter under the integration domain:
+Entity filtering is configured via `configuration.yaml` and mirrors [HA recorder semantics](https://www.home-assistant.io/integrations/recorder/#configure-filter). Omitting the filter block ingests all entities.
 
 ```yaml
 ha_timescaledb_recorder:
@@ -67,17 +68,31 @@ ha_timescaledb_recorder:
     domains:
       - sensor
       - binary_sensor
-      - switch
-  exclude:
     entities:
-      - sensor.some_noisy_sensor
+      - switch.living_room_light
     entity_globs:
       - sensor.weather_*
+  exclude:
+    domains:
+      - media_player
+    entities:
+      - sensor.debug_probe
+    entity_globs:
+      - sensor.*_internal
 ```
 
-When no filter is configured, all entities are ingested.
+Filter behaviour:
 
-Include/exclude precedence follows the same rules as the HA recorder. See the [HA recorder filter documentation](https://www.home-assistant.io/integrations/recorder/#configure-filter) for the full precedence matrix.
+- `include.domains` — only states from these domains are ingested
+- `include.entities` — only these specific entity IDs are ingested
+- `include.entity_globs` — only entities matching these glob patterns are ingested
+- `exclude.domains`, `exclude.entities`, `exclude.entity_globs` — exclude matching entities even if they satisfy an include rule
+- All keys are optional; omitting both `include` and `exclude` ingests all entities
+- When only `include` is specified, non-matching entities are dropped (allow-list)
+- When only `exclude` is specified, matching entities are dropped (deny-list)
+- When both are specified, HA recorder precedence rules apply: include first, then exclude wins
+
+> **Note:** Filter configuration requires a **Home Assistant restart** to take effect — changes are not picked up by a config entry reload, because `async_setup` (which reads the YAML filter) only runs at startup.
 
 ## Schema
 

--- a/custom_components/ha_timescaledb_recorder/__init__.py
+++ b/custom_components/ha_timescaledb_recorder/__init__.py
@@ -27,11 +27,14 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Callable
 
+import voluptuous as vol
+
 from homeassistant.components import recorder as ha_recorder
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import area_registry as ar
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import label_registry as lr
@@ -66,6 +69,41 @@ from .registry_listener import RegistryListener, _to_json_safe
 from .watchdog import spawn_meta_worker, spawn_states_worker, watchdog_loop
 
 _LOGGER = logging.getLogger(__name__)
+
+# Voluptuous schema for one include/exclude block inside the YAML config.
+# Each key is optional — missing keys default to an empty list so
+# convert_include_exclude_filter always receives well-formed dicts.
+_FILTER_SCHEMA_INNER = vol.Schema({
+    vol.Optional("domains", default=[]): vol.All(list, [cv.string]),
+    vol.Optional("entities", default=[]): vol.All(list, [cv.string]),
+    vol.Optional("entity_globs", default=[]): vol.All(list, [cv.string]),
+})
+
+# CONFIG_SCHEMA is required for HA to call async_setup before async_setup_entry.
+# ALLOW_EXTRA lets other integrations' top-level keys pass through validation —
+# HA validates the full configuration.yaml against every component's schema.
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema({
+            vol.Optional("include"): _FILTER_SCHEMA_INNER,
+            vol.Optional("exclude"): _FILTER_SCHEMA_INNER,
+        }),
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Store YAML filter config in hass.data before config entries are set up.
+
+    HA guarantees async_setup runs before any async_setup_entry call for this
+    domain, so the filter dict is always present in hass.data by the time
+    _get_entity_filter reads it during entry setup.
+    """
+    domain_config = config.get(DOMAIN, {})
+    hass.data.setdefault(DOMAIN, {})["filter"] = domain_config
+    return True
+
 
 # Sleep interval for the overflow watcher task. Small enough to notice the
 # flag flip quickly, large enough to be effectively free. The watcher only
@@ -103,9 +141,15 @@ class HaTimescaleDBData:
 HaTimescaleDBConfigEntry = ConfigEntry[HaTimescaleDBData]
 
 
-def _get_entity_filter(entry):
-    """Build entity filter from config entry data (unchanged from Phase 1)."""
-    raw_filter = entry.data.get("filter", {})
+def _get_entity_filter(hass: HomeAssistant, entry):
+    """Build entity filter from YAML config stored in hass.data.
+
+    entry.data never carries a filter key (config-flow entries only store the
+    DSN), so the old entry.data path was permanently pass-all. The YAML filter
+    is now the authoritative source, stored by async_setup before this runs.
+    Falls back to pass-all when no YAML filter is configured.
+    """
+    raw_filter = hass.data.get(DOMAIN, {}).get("filter", {})
     if raw_filter:
         return convert_include_exclude_filter(raw_filter)
     return convert_filter({
@@ -334,7 +378,7 @@ async def async_setup_entry(
     options = entry.options
     chunk_interval_days = options.get(CONF_CHUNK_INTERVAL, DEFAULT_CHUNK_INTERVAL_DAYS)
     compress_after_hours = options.get(CONF_COMPRESS_AFTER, DEFAULT_COMPRESS_AFTER_HOURS)
-    entity_filter = _get_entity_filter(entry)
+    entity_filter = _get_entity_filter(hass, entry)
 
     # D-12 step 1: open PersistentQueue
     meta_queue = PersistentQueue(hass.config.path(DOMAIN, "metadata_queue.jsonl"))

--- a/custom_components/ha_timescaledb_recorder/__init__.py
+++ b/custom_components/ha_timescaledb_recorder/__init__.py
@@ -42,6 +42,7 @@ from homeassistant.helpers.entityfilter import (
     convert_filter,
     convert_include_exclude_filter,
 )
+from homeassistant.helpers.reload import async_integration_yaml_config
 
 from .backfill import backfill_orchestrator
 from .const import (
@@ -102,6 +103,16 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """
     domain_config = config.get(DOMAIN, {})
     hass.data.setdefault(DOMAIN, {})["filter"] = domain_config
+
+    async def _async_reload_filter(call) -> None:
+        # Re-parse configuration.yaml and reload all config entries so the new
+        # filter takes effect without a full HA restart.
+        fresh = await async_integration_yaml_config(hass, DOMAIN)
+        hass.data.setdefault(DOMAIN, {})["filter"] = (fresh or {}).get(DOMAIN, {})
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            await hass.config_entries.async_reload(entry.entry_id)
+
+    hass.services.async_register(DOMAIN, "reload", _async_reload_filter)
     return True
 
 


### PR DESCRIPTION
## Summary

- Wire `CONFIG_SCHEMA` + `async_setup` so entity filters in `configuration.yaml` are applied (previously dead code — `entry.data` never carried a filter key)
- Add `ha_timescaledb_recorder.reload` service to re-parse YAML and reload config entries without HA restart
- Update README: full filter docs, YAML example, reload instructions

## Test plan

- [x] Add `include`/`exclude` block to `configuration.yaml`, restart HA — verify only matching entities ingested
- [x] Change filter, click Settings → Developer tools → YAML → YAML configuration reloading → TimescaleDB Recorder — verify new filter applied without restart
- [x] No filter configured — verify all entities still ingested (pass-all fallback)

Closes #3 .